### PR TITLE
Add entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ python-dotenv = "^1.0.1"
 [tool.poetry.group.dev.dependencies]
 ruff = "0.4.4"
 
+[tool.poetry.scripts]
+scan = "scan.main:main"
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ python-dotenv = "^1.0.1"
 ruff = "0.4.4"
 
 [tool.poetry.scripts]
-scan = "scan.main:main"
+run-scan = "scan.main:main"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
This further simplifies the startup by adding an option to just type `run-scan` to start the program.